### PR TITLE
Create Loader cache decorators to save feed

### DIFF
--- a/.github/workflows/CI-iOS.yml
+++ b/.github/workflows/CI-iOS.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Select Xcode
+      run: sudo xcode-select -switch /Applications/Xcode_12.2.app
+      
+    - name: Xcode version
+      run: /usr/bin/xcodebuild -version
+
+    - name: Build and test CI iOS
+      run: xcodebuild clean build test -workspace EssentialApp/EssentialApp.xcworkspace -scheme "CI_iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=14.2,name=iPhone 12 Pro Max" ONLY_ACTIVE_ARCH=YES

--- a/.github/workflows/CI-macOS.yml
+++ b/.github/workflows/CI-macOS.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Select Xcode
       run: sudo xcode-select -switch /Applications/Xcode_12.2.app
 
+    - name: Xcode version
+      run: /usr/bin/xcodebuild -version
+
     - name: Build and test CI macOS
       run: xcodebuild clean build test -project EssentialFeed.xcodeproj -scheme "CI_macOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk macosx -destination "platform=macOS" ONLY_ACTIVE_ARCH=YES
-
-    - name: Build and test CI iOS
-      run: xcodebuild clean build test -workspace EssentialApp/EssentialApp.xcworkspace -scheme "CI_iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,OS=14.2,name=iPhone 12 Pro Max" ONLY_ACTIVE_ARCH=YES

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		A11DDAD825D23869009A382F /* FeedImageDataLoaderWithFallBackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11DDAD425D23844009A382F /* FeedImageDataLoaderWithFallBackComposite.swift */; };
 		A11DDADF25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11DDADE25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift */; };
 		A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11DDAE425D23985009A382F /* SharedTestHelpers.swift */; };
+		A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -56,6 +57,7 @@
 		A11DDAD425D23844009A382F /* FeedImageDataLoaderWithFallBackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallBackComposite.swift; sourceTree = "<group>"; };
 		A11DDADE25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		A11DDAE425D23985009A382F /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
+		A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 				A1ADBB2D25CA3BF000B12503 /* FeedLoaderWithFallbackCompositeTests.swift */,
 				A1ADBB2F25CA3BF000B12503 /* Info.plist */,
 				A11DDAD025D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift */,
+				A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */,
+				A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				A11DDAD125D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift in Sources */,
 				A1ADBB2E25CA3BF000B12503 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				A11DDADF25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */; };
 		A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */; };
 		A1806C7C25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */; };
+		A1806C7F25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -64,6 +65,7 @@
 		A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
+		A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheImageDecoratorTests.swift; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				A1ADBB2F25CA3BF000B12503 /* Info.plist */,
 				A11DDAD025D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift */,
 				A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */,
+				A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */,
 				A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */,
 				A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
+				A1806C7F25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift in Sources */,
 				A11DDAD125D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift in Sources */,
 				A1ADBB2E25CA3BF000B12503 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */; };
 		A1806C7C25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */; };
 		A1806C7F25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */; };
+		A1806C8225D6154D00BD0812 /* FeedImageLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -66,6 +67,7 @@
 		A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheImageDecoratorTests.swift; sourceTree = "<group>"; };
+		A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageLoaderSpy.swift; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				A11DDAE425D23985009A382F /* SharedTestHelpers.swift */,
 				A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */,
 				A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */,
+				A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -285,6 +288,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */,
+				A1806C8225D6154D00BD0812 /* FeedImageLoaderSpy.swift in Sources */,
 				A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */,
 				A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				A1806C7F25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11DDAE425D23985009A382F /* SharedTestHelpers.swift */; };
 		A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */; };
 		A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */; };
+		A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -60,6 +61,7 @@
 		A11DDAE425D23985009A382F /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -101,6 +103,7 @@
 				A11DDADE25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift */,
 				A11DDAE425D23985009A382F /* SharedTestHelpers.swift */,
 				A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */,
+				A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */,
+				A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */,
 				A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				A11DDAD125D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift in Sources */,
 				A1ADBB2E25CA3BF000B12503 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A11DDADF25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11DDADE25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift */; };
 		A11DDAE525D23985009A382F /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11DDAE425D23985009A382F /* SharedTestHelpers.swift */; };
 		A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */; };
+		A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -58,6 +59,7 @@
 		A11DDADE25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+MemoryLeakTracking.swift"; sourceTree = "<group>"; };
 		A11DDAE425D23985009A382F /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 			children = (
 				A11DDADE25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift */,
 				A11DDAE425D23985009A382F /* SharedTestHelpers.swift */,
+				A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -275,6 +278,7 @@
 				A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				A11DDAD125D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift in Sources */,
 				A1ADBB2E25CA3BF000B12503 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */,
 				A11DDADF25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A1806C7F25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */; };
 		A1806C8225D6154D00BD0812 /* FeedImageLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */; };
 		A1806C8525D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8425D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift */; };
+		A1806C9025D6186000BD0812 /* FeedLoaderCacheImageDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8F25D6186000BD0812 /* FeedLoaderCacheImageDecorator.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -70,6 +71,7 @@
 		A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheImageDecoratorTests.swift; sourceTree = "<group>"; };
 		A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageLoaderSpy.swift; sourceTree = "<group>"; };
 		A1806C8425D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageLoader.swift"; sourceTree = "<group>"; };
+		A1806C8F25D6186000BD0812 /* FeedLoaderCacheImageDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheImageDecorator.swift; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 				A1164AA625CCF963004DDF30 /* FeedLoaderWithFallbackComposite.swift */,
 				A11DDAD425D23844009A382F /* FeedImageDataLoaderWithFallBackComposite.swift */,
 				A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */,
+				A1806C8F25D6186000BD0812 /* FeedLoaderCacheImageDecorator.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 				A1806C7C25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift in Sources */,
 				A1164AA725CCF963004DDF30 /* FeedLoaderWithFallbackComposite.swift in Sources */,
 				A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */,
+				A1806C9025D6186000BD0812 /* FeedLoaderCacheImageDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A1806C6B25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */; };
 		A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */; };
 		A1806C7125D3907100BD0812 /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */; };
+		A1806C7C25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -62,6 +63,7 @@
 		A1806C6A25D383BE00BD0812 /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 		A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
+		A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				A1ADBB2425CA3BF000B12503 /* Info.plist */,
 				A1164AA625CCF963004DDF30 /* FeedLoaderWithFallbackComposite.swift */,
 				A11DDAD425D23844009A382F /* FeedImageDataLoaderWithFallBackComposite.swift */,
+				A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 				A11DDAD825D23869009A382F /* FeedImageDataLoaderWithFallBackComposite.swift in Sources */,
 				A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */,
 				A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */,
+				A1806C7C25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift in Sources */,
 				A1164AA725CCF963004DDF30 /* FeedLoaderWithFallbackComposite.swift in Sources */,
 				A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */,
 			);

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A1806C7C25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */; };
 		A1806C7F25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */; };
 		A1806C8225D6154D00BD0812 /* FeedImageLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */; };
+		A1806C8525D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8425D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift */; };
 		A1ADBB1725CA3BED00B12503 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */; };
 		A1ADBB1925CA3BED00B12503 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */; };
 		A1ADBB1B25CA3BED00B12503 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1ADBB1A25CA3BED00B12503 /* ViewController.swift */; };
@@ -68,6 +69,7 @@
 		A1806C7B25D42E8400BD0812 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		A1806C7E25D5F66800BD0812 /* FeedLoaderCacheImageDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheImageDecoratorTests.swift; sourceTree = "<group>"; };
 		A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageLoaderSpy.swift; sourceTree = "<group>"; };
+		A1806C8425D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageLoader.swift"; sourceTree = "<group>"; };
 		A1ADBB1325CA3BED00B12503 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1ADBB1625CA3BED00B12503 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A1ADBB1825CA3BED00B12503 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				A1806C6D25D38F2300BD0812 /* FeedLoaderStub.swift */,
 				A1806C7025D3907100BD0812 /* XCTestCase+FeedLoader.swift */,
 				A1806C8125D6154D00BD0812 /* FeedImageLoaderSpy.swift */,
+				A1806C8425D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -295,6 +298,7 @@
 				A11DDAD125D21FCB009A382F /* FeedImageDataLoaderWithFallBackCompositeTests.swift in Sources */,
 				A1ADBB2E25CA3BF000B12503 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				A1806C6E25D38F2300BD0812 /* FeedLoaderStub.swift in Sources */,
+				A1806C8525D6161D00BD0812 /* XCTestCase+FeedImageLoader.swift in Sources */,
 				A11DDADF25D238F2009A382F /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -19,9 +19,15 @@ public class FeedLoaderCacheDecorator: FeedLoader {
     public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
+                self?.cache.saveIgnoringError(feed)
                 return feed
             })
         }
+    }
+}
+
+private extension FeedCache {
+    func saveIgnoringError(_ feed: [FeedImage]) {
+        save(feed) { _ in }
     }
 }

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -5,7 +5,6 @@
 //  Created by Jair Moreno Gaspar on 10/02/21.
 //
 
-import Foundation
 import EssentialFeed
 
 public class FeedLoaderCacheDecorator: FeedLoader {

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,28 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Jair Moreno Gaspar on 10/02/21.
+//
+
+import Foundation
+import EssentialFeed
+
+public class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+    
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            completion(result.map { feed in
+                self?.cache.save(feed) { _ in }
+                return feed
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheImageDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheImageDecorator.swift
@@ -1,0 +1,30 @@
+//
+//  FeedLoaderCacheImageDecorator.swift
+//  EssentialApp
+//
+//  Created by Jair Moreno Gaspar on 11/02/21.
+//
+
+import Foundation
+import EssentialFeed
+
+public class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
+
+    private let loader: FeedImageDataLoader
+    private let cache: FeedImageCache
+    
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageCache) {
+        self.loader = decoratee
+        self.cache = cache
+    }
+    
+    public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        let task = loader.loadImageData(from: url, completion: { [weak self] result in
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
+        })
+        return task
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheImageDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheImageDecorator.swift
@@ -21,10 +21,16 @@ public class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
     public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         let task = loader.loadImageData(from: url, completion: { [weak self] result in
             completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringError(data, url: url)
                 return data
             })
         })
         return task
+    }
+}
+
+private extension FeedImageCache {
+    func saveIgnoringError(_ data: Data, url: URL) {
+        save(data, for: url) { _ in }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallBackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallBackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedImageDataLoaderWithFallBackCompositeTests: XCTestCase {
+class FeedImageDataLoaderWithFallBackCompositeTests: XCTestCase, FeedImageLoaderTestCase {
     
     func test_load_doesNotLoadImageUponCreation() {
         let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -91,29 +91,6 @@ class FeedImageDataLoaderWithFallBackCompositeTests: XCTestCase {
     }
     
     // MARK: - Helpers
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: (FeedImageDataLoader.Result), when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-            case (.failure, .failure):
-                break
-
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
-        }
-
-        action()
-
-        wait(for: [exp], timeout: 1.0)
-    }
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primaryLoader: FeedImageLoaderSpy, fallbackLoader: FeedImageLoaderSpy) {
         let primaryLoader = FeedImageLoaderSpy()

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallBackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallBackCompositeTests.swift
@@ -115,49 +115,14 @@ class FeedImageDataLoaderWithFallBackCompositeTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primaryLoader: LoaderSpy, fallbackLoader: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primaryLoader: FeedImageLoaderSpy, fallbackLoader: FeedImageLoaderSpy) {
+        let primaryLoader = FeedImageLoaderSpy()
+        let fallbackLoader = FeedImageLoaderSpy()
         let sut = FeedImageDataLoaderWithFallBackComposite(primaryLoader: primaryLoader, fallbackLoader: fallbackLoader)
         trackForMemoryLeaks(instance: primaryLoader, file: file, line: line)
         trackForMemoryLeaks(instance: fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(instance: sut, file: file, line: line)
         return (sut, primaryLoader, fallbackLoader)
-    }
-    
-    private class LoaderSpy: FeedImageDataLoader {
-        
-        private var messages: [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)] = []
-        private(set) var cancelledURLs: [URL] = []
-        
-        var loadedURLs: [URL] {
-            messages.map { $0.url }
-        }
-        
-        private struct Task: FeedImageDataLoaderTask {
-            
-            let callback: () -> Void
-            
-            
-            func cancel() {
-                callback()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-    typealias SaveResult = Result<Void, Error>
-    
-    func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void)
-}
-
 class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
     private let cache: FeedCache

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-class FeedLoaderCacheDecorator: FeedLoader {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-    
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            completion(result.map { feed in
-                self?.cache.save(feed) { _ in }
-                return feed
-            })
-        }
-    }
-}
+import EssentialApp
 
 class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ class FeedLoaderCacheDecorator: FeedLoader {
     }
 }
 
-class FeedLoaderCacheDecoratorTests: XCTestCase {
+class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnSuccess() {
         let feed = uniqueFeed()
@@ -45,24 +45,5 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         trackForMemoryLeaks(instance: sut, file: file, line: line)
         return sut
     }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        
-        let exp = expectation(description: "Wait for load completion")
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-            case (.failure, .failure):
-                break
-            default:
-                XCTFail("Expected successful load feed result, got \(receivedResult) instead")
-            }
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1)
-        
-    }
-
 
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,10 +25,10 @@ class FeedLoaderCacheDecorator: FeedLoader {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            if case let .success(feed) = result {
+            completion(result.map { feed in
                 self?.cache.save(feed) { _ in }
-            }
-            completion(result)
+                return feed
+            })
         }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,88 @@
+//
+//  FeedLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Jair Moreno Gaspar on 09/02/21.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+class FeedLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_load_deliversFeedOnSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = makeSUT(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .success(feed))
+    }
+    
+    func test_load_deliversErrorOnLoaderFailure() {
+        let error = anyNSError()
+        let loader = LoaderStub(result: .failure(error))
+        let sut = makeSUT(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .failure(error))
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSUT(decoratee: FeedLoader, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+        let sut = FeedLoaderCacheDecorator(decoratee: decoratee)
+        trackForMemoryLeaks(instance: sut, file: file, line: line)
+        return sut
+    }
+    
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        
+        let exp = expectation(description: "Wait for load completion")
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+            case (.failure, .failure):
+                break
+            default:
+                XCTFail("Expected successful load feed result, got \(receivedResult) instead")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        
+    }
+    
+    private func uniqueFeed() -> [FeedImage] {
+        return [FeedImage(id: UUID(),
+                          description: "any",
+                          location: "any",
+                          url: anyURL())]
+    }
+    
+    private class LoaderStub: FeedLoader {
+        
+        private let result: FeedLoader.Result
+        
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+        
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+
+    }
+    
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,7 +24,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     func test_load_deliversFeedOnSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = makeSUT(decoratee: loader)
         
         expect(sut, toCompleteWith: .success(feed))
@@ -32,7 +32,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     func test_load_deliversErrorOnLoaderFailure() {
         let error = anyNSError()
-        let loader = LoaderStub(result: .failure(error))
+        let loader = FeedLoaderStub(result: .failure(error))
         let sut = makeSUT(decoratee: loader)
         
         expect(sut, toCompleteWith: .failure(error))
@@ -63,26 +63,6 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         wait(for: [exp], timeout: 1)
         
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(),
-                          description: "any",
-                          location: "any",
-                          url: anyURL())]
-    }
-    
-    private class LoaderStub: FeedLoader {
-        
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
 
-    }
-    
+
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -56,7 +56,16 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         
         sut.load { _ in }
         
-        XCTAssertEqual(cache.messages, [.save(feed)])
+        XCTAssertEqual(cache.messages, [.save(feed)], "Expected cache loaded feed on success")
+    }
+    
+    func test_load_doesNotCacheOnLoaderFailure() {
+        let cache = CacheSpy()
+        let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache feed on load error")
     }
     
     // MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -79,7 +79,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
             case save([FeedImage])
         }
         
-        func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
+        func save(_ feed: [FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
             messages.append(.save(feed))
             completion(.success(()))
         }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,25 +24,25 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = makeSUT(decoratee: loader)
+        let sut = makeSUT(loaderResult: .success(feed))
         
         expect(sut, toCompleteWith: .success(feed))
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
         let error = anyNSError()
-        let loader = FeedLoaderStub(result: .failure(error))
-        let sut = makeSUT(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(error))
         
         expect(sut, toCompleteWith: .failure(error))
     }
     
     // MARK: - Helpers
     
-    private func makeSUT(decoratee: FeedLoader, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-        let sut = FeedLoaderCacheDecorator(decoratee: decoratee)
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
         trackForMemoryLeaks(instance: sut, file: file, line: line)
+        trackForMemoryLeaks(instance: loader, file: file, line: line)
         return sut
     }
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -35,7 +35,7 @@ class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
     }
 }
 
-class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
+class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedImageLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
         let (_, loader) = makeSUT()
@@ -130,28 +130,4 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
         }
         
     }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: (FeedImageDataLoader.Result), when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-
-            case (.failure, .failure):
-                break
-
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
-        }
-
-        action()
-
-        wait(for: [exp], timeout: 1.0)
-    }
-    
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -32,10 +32,10 @@ class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
     
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         _ = loader.loadImageData(from: url, completion: { [weak self] result in
-            if case let .success(data) = result {
+            completion(result.map { data in
                 self?.cache.save(data, for: url) { _ in }
-            }
-            completion(result)
+                return data
+            })
         })
         return Task()
     }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -49,6 +49,15 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
         XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
     }
     
+    func test_loadImageData_loadsFromLoader() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+
+        _ = sut.loadImageData(from: url) { _ in }
+
+        XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+    }
+    
     func test_load_deliversImageDataFeedOnSuccess() {
         let (sut, loader) = makeSUT()
         let data = anyData()

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -43,6 +43,12 @@ class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
 
 class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
+    func test_init_doesNotLoadImageData() {
+        let (_, loader) = makeSUT()
+
+        XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URLs")
+    }
+    
     func test_load_deliversImageDataFeedOnSuccess() {
         let (sut, loader) = makeSUT()
         let data = anyData()
@@ -85,6 +91,8 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
         XCTAssertTrue(cache.messages.isEmpty, "Expect to not cache data after loader failure")
     }
     
+    
+    
     // MARK: - Helpers
     
     private func makeSUT(cache: CacheImageSpy = .init(), file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageLoaderSpy) {
@@ -113,6 +121,12 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
     private class FeedImageLoaderSpy: FeedImageDataLoader {
         
         private var messages: [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)] = []
+        
+        private(set) var cancelledURLs = [URL]()
+
+        var loadedURLs: [URL] {
+            return messages.map { $0.url }
+        }
         
         private struct Task: FeedImageDataLoaderTask {
             func cancel() {

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -7,29 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-
-
-class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
-
-    private let loader: FeedImageDataLoader
-    private let cache: FeedImageCache
-    
-    init(decoratee: FeedImageDataLoader, cache: FeedImageCache) {
-        self.loader = decoratee
-        self.cache = cache
-    }
-    
-    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-        let task = loader.loadImageData(from: url, completion: { [weak self] result in
-            completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            })
-        })
-        return task
-    }
-}
+import EssentialApp
 
 class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedImageLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -120,7 +120,7 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedImageLoaderTestCase {
             case save(Data)
         }
         
-        func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void) {
+        func save(_ data: Data, for url: URL, completion: @escaping (FeedImageCache.Result) -> Void) {
             messages.append(.save(data))
             completion(.success(()))
         }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -31,8 +31,7 @@ class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
 class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversImageDataFeedOnSuccess() {
-        let loader = FeedImageLoaderSpy()
-        let sut = FeedLoaderCacheImageDecorator(decoratee: loader)
+        let (sut, loader) = makeSUT()
         let data = anyData()
         
         expect(sut, toCompleteWith: .success(data)) {
@@ -42,12 +41,21 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversErrorOnImageLoaderFailure() {
         let error = anyNSError()
-        let loader = FeedImageLoaderSpy()
-        let sut = FeedLoaderCacheImageDecorator(decoratee: loader)
+        let (sut, loader) = makeSUT()
         
         expect(sut, toCompleteWith: .failure(error)) {
             loader.complete(with: error)
         }
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageLoaderSpy) {
+        let loader = FeedImageLoaderSpy()
+        let sut = FeedLoaderCacheImageDecorator(decoratee: loader)
+        trackForMemoryLeaks(instance: loader, file: file, line: line)
+        trackForMemoryLeaks(instance: sut, file: file, line: line)
+        return (sut, loader)
     }
     
     private class FeedImageLoaderSpy: FeedImageDataLoader {

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -131,41 +131,6 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
         
     }
     
-    private class FeedImageLoaderSpy: FeedImageDataLoader {
-        
-        private var messages: [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)] = []
-        
-        private(set) var cancelledURLs = [URL]()
-
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            
-            func cancel() {
-                callback()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-    }
-    
     private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: (FeedImageDataLoader.Result), when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
         let exp = expectation(description: "Wait for load completion")
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -70,7 +70,7 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
             loader.complete(with: data)
         }
         
-        XCTAssertEqual(cache.messages, [.save(data)])
+        XCTAssertEqual(cache.messages, [.save(data)], "Expected data cached on loader success")
     }
     
     func test_load_doesNotcacheFeedImageOnLoaderFailure() {
@@ -82,7 +82,7 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
             loader.complete(with: error)
         }
         
-        XCTAssertTrue(cache.messages.isEmpty)
+        XCTAssertTrue(cache.messages.isEmpty, "Expect to not cache data after loader failure")
     }
     
     // MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -8,11 +8,7 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedImageCache {
-    typealias SaveResult = Result<Void, Swift.Error>
-    
-    func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void)
-}
+
 
 class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -24,12 +24,6 @@ class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
         self.cache = cache
     }
     
-    private struct Task: FeedImageDataLoaderTask {
-        func cancel() {
-            
-        }
-    }
-    
     func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
         let task = loader.loadImageData(from: url, completion: { [weak self] result in
             completion(result.map { data in

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -73,6 +73,18 @@ class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
         XCTAssertEqual(cache.messages, [.save(data)])
     }
     
+    func test_load_doesNotcacheFeedImageOnLoaderFailure() {
+        let cache = CacheImageSpy()
+        let (sut, loader) = makeSUT(cache: cache)
+        let error = anyNSError()
+        
+        expect(sut, toCompleteWith: .failure(error)) {
+            loader.complete(with: error)
+        }
+        
+        XCTAssertTrue(cache.messages.isEmpty)
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(cache: CacheImageSpy = .init(), file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, loader: FeedImageLoaderSpy) {

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheImageDecoratorTests.swift
@@ -1,0 +1,101 @@
+//
+//  FeedLoaderCacheImageDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Jair Moreno Gaspar on 11/02/21.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedLoaderCacheImageDecorator: FeedImageDataLoader {
+
+    private let loader: FeedImageDataLoader
+    
+    init(decoratee: FeedImageDataLoader) {
+        self.loader = decoratee
+    }
+    
+    private struct Task: FeedImageDataLoaderTask {
+        func cancel() {
+            
+        }
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        _ = loader.loadImageData(from: url, completion: completion)
+        return Task()
+    }
+}
+
+class FeedLoaderCacheImageDecoratorTests: XCTestCase, FeedLoaderTestCase {
+    
+    func test_load_deliversImageDataFeedOnSuccess() {
+        let loader = FeedImageLoaderSpy()
+        let sut = FeedLoaderCacheImageDecorator(decoratee: loader)
+        let data = anyData()
+        
+        expect(sut, toCompleteWith: .success(data)) {
+            loader.complete(with: data)
+        }
+    }
+    
+    func test_load_deliversErrorOnImageLoaderFailure() {
+        let error = anyNSError()
+        let loader = FeedImageLoaderSpy()
+        let sut = FeedLoaderCacheImageDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .failure(error)) {
+            loader.complete(with: error)
+        }
+    }
+    
+    private class FeedImageLoaderSpy: FeedImageDataLoader {
+        
+        private var messages: [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)] = []
+        
+        private struct Task: FeedImageDataLoaderTask {
+            func cancel() {
+                
+            }
+        }
+        
+        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+            messages.append((url, completion))
+            return Task()
+        }
+        
+        func complete(with data: Data, at index: Int = 0) {
+            messages[index].completion(.success(data))
+        }
+        
+        func complete(with error: Error, at index: Int = 0) {
+            messages[index].completion(.failure(error))
+        }
+        
+    }
+    
+    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: (FeedImageDataLoader.Result), when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+            case (.failure, .failure):
+                break
+
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        action()
+
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -34,8 +34,8 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
 
     // MARK: - Helpers
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         
         trackForMemoryLeaks(instance: primaryLoader, file: file, line: line)
@@ -63,22 +63,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     }
 
     
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(),
-                          description: "any",
-                          location: "any",
-                          url: anyURL())]
-    }
-    
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
-    }
+
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialApp
 import EssentialFeed
 
-class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
 
     func test_load_deliversPrimaryFeedOnPrimaryLoaderSuccess() {
         let primaryFeed = uniqueFeed()
@@ -43,25 +43,4 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(instance: sut, file: file, line: line)
         return sut
     }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        
-        let exp = expectation(description: "Wait for load completion")
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-            case (.failure, .failure):
-                break
-            default:
-                XCTFail("Expected successful load feed result, got \(receivedResult) instead")
-            }
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1)
-        
-    }
-
-    
-
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageLoaderSpy.swift
@@ -1,0 +1,44 @@
+//
+//  FeedImageLoaderSpy.swift
+//  EssentialAppTests
+//
+//  Created by Jair Moreno Gaspar on 11/02/21.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedImageLoaderSpy: FeedImageDataLoader {
+    
+    private var messages: [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)] = []
+    
+    private(set) var cancelledURLs = [URL]()
+
+    var loadedURLs: [URL] {
+        return messages.map { $0.url }
+    }
+    
+    private struct Task: FeedImageDataLoaderTask {
+        let callback: () -> Void
+        
+        func cancel() {
+            callback()
+        }
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> FeedImageDataLoaderTask {
+        messages.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+    
+    func complete(with data: Data, at index: Int = 0) {
+        messages[index].completion(.success(data))
+    }
+    
+    func complete(with error: Error, at index: Int = 0) {
+        messages[index].completion(.failure(error))
+    }
+    
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,23 @@
+//
+//  FeedLoaderStub.swift
+//  EssentialAppTests
+//
+//  Created by Jair Moreno Gaspar on 09/02/21.
+//
+
+import Foundation
+import EssentialFeed
+
+class FeedLoaderStub: FeedLoader {
+    
+    private let result: FeedLoader.Result
+    
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-
+import EssentialFeed
 
 func anyNSError() -> NSError {
     return NSError(domain: "any error", code: 0)
@@ -18,4 +18,11 @@ func anyURL() -> URL {
 
 func anyData() -> Data {
     return Data("any data".utf8)
+}
+
+func uniqueFeed() -> [FeedImage] {
+    return [FeedImage(id: UUID(),
+                      description: "any",
+                      location: "any",
+                      url: anyURL())]
 }

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageLoader.swift
@@ -1,0 +1,36 @@
+//
+//  XCTestCase+FeedImageLoader.swift
+//  EssentialAppTests
+//
+//  Created by Jair Moreno Gaspar on 11/02/21.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedImageLoaderTestCase: XCTestCase {}
+
+extension FeedImageLoaderTestCase {
+    func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: (FeedImageDataLoader.Result), when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+
+            case (.failure, .failure):
+                break
+
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+
+            exp.fulfill()
+        }
+
+        action()
+
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,31 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  EssentialAppTests
+//
+//  Created by Jair Moreno Gaspar on 09/02/21.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        
+        let exp = expectation(description: "Wait for load completion")
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+            case (.failure, .failure):
+                break
+            default:
+                XCTFail("Expected successful load feed result, got \(receivedResult) instead")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        
+    }
+}

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		A17EF2BA25631E07009D559C /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EF2B925631E07009D559C /* FeedCacheTestHelpers.swift */; };
 		A17EF2BC25631ECE009D559C /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EF2BB25631ECE009D559C /* SharedTestHelpers.swift */; };
 		A1806C7425D42D5C00BD0812 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7325D42D5C00BD0812 /* FeedCache.swift */; };
+		A1806C8825D6172900BD0812 /* FeedImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C8725D6172900BD0812 /* FeedImageCache.swift */; };
 		A1A9278C25BF9CBD006E1DD8 /* LoadFeedImageDataFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9278B25BF9CBD006E1DD8 /* LoadFeedImageDataFromCacheUseCaseTests.swift */; };
 		A1A9279425BFAD47006E1DD8 /* FeedImageDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9279325BFAD47006E1DD8 /* FeedImageDataStore.swift */; };
 		A1A9279C25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9279B25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift */; };
@@ -160,6 +161,7 @@
 		A17EF2B925631E07009D559C /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
 		A17EF2BB25631ECE009D559C /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
 		A1806C7325D42D5C00BD0812 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
+		A1806C8725D6172900BD0812 /* FeedImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCache.swift; sourceTree = "<group>"; };
 		A1A9278B25BF9CBD006E1DD8 /* LoadFeedImageDataFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedImageDataFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		A1A9279325BFAD47006E1DD8 /* FeedImageDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataStore.swift; sourceTree = "<group>"; };
 		A1A9279B25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImageDataLoader.swift; sourceTree = "<group>"; };
@@ -593,6 +595,7 @@
 				C634042325259563005092C5 /* FeedImage.swift */,
 				C63404252525975A005092C5 /* FeedLoader.swift */,
 				A1806C7325D42D5C00BD0812 /* FeedCache.swift */,
+				A1806C8725D6172900BD0812 /* FeedImageCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -926,6 +929,7 @@
 				C6733DD1252EB23F0011B6B0 /* FeedItemsMapper.swift in Sources */,
 				C63404262525975A005092C5 /* FeedLoader.swift in Sources */,
 				A1D80FDB255C332F001224C3 /* RemoteFeedItem.swift in Sources */,
+				A1806C8825D6172900BD0812 /* FeedImageCache.swift in Sources */,
 				A1D2EF6A25AA7ABE009B0394 /* FeedImageViewModel.swift in Sources */,
 				A12FF2B325BA5A0E00C7E730 /* RemoteFeedImageDataLoader.swift in Sources */,
 				A11038112564B71D003DB1BF /* FeedCachePolicy.swift in Sources */,

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		A17EF2B825631846009D559C /* ValidateFeedCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EF2B725631846009D559C /* ValidateFeedCacheUseCaseTests.swift */; };
 		A17EF2BA25631E07009D559C /* FeedCacheTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EF2B925631E07009D559C /* FeedCacheTestHelpers.swift */; };
 		A17EF2BC25631ECE009D559C /* SharedTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EF2BB25631ECE009D559C /* SharedTestHelpers.swift */; };
+		A1806C7425D42D5C00BD0812 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1806C7325D42D5C00BD0812 /* FeedCache.swift */; };
 		A1A9278C25BF9CBD006E1DD8 /* LoadFeedImageDataFromCacheUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9278B25BF9CBD006E1DD8 /* LoadFeedImageDataFromCacheUseCaseTests.swift */; };
 		A1A9279425BFAD47006E1DD8 /* FeedImageDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9279325BFAD47006E1DD8 /* FeedImageDataStore.swift */; };
 		A1A9279C25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A9279B25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift */; };
@@ -158,6 +159,7 @@
 		A17EF2B725631846009D559C /* ValidateFeedCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateFeedCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		A17EF2B925631E07009D559C /* FeedCacheTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCacheTestHelpers.swift; sourceTree = "<group>"; };
 		A17EF2BB25631ECE009D559C /* SharedTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestHelpers.swift; sourceTree = "<group>"; };
+		A1806C7325D42D5C00BD0812 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		A1A9278B25BF9CBD006E1DD8 /* LoadFeedImageDataFromCacheUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadFeedImageDataFromCacheUseCaseTests.swift; sourceTree = "<group>"; };
 		A1A9279325BFAD47006E1DD8 /* FeedImageDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataStore.swift; sourceTree = "<group>"; };
 		A1A9279B25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFeedImageDataLoader.swift; sourceTree = "<group>"; };
@@ -590,6 +592,7 @@
 				A1D2ED44259E4051009B0394 /* FeedImageLoader.swift */,
 				C634042325259563005092C5 /* FeedImage.swift */,
 				C63404252525975A005092C5 /* FeedLoader.swift */,
+				A1806C7325D42D5C00BD0812 /* FeedCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -946,6 +949,7 @@
 				A1A9279C25BFAD9C006E1DD8 /* LocalFeedImageDataLoader.swift in Sources */,
 				A1A927E825C2511B006E1DD8 /* CoreDataFeedStore+FeedImageDataLoader.swift in Sources */,
 				A1D2EF6925AA7ABE009B0394 /* FeedImagePresenter.swift in Sources */,
+				A1806C7425D42D5C00BD0812 /* FeedCache.swift in Sources */,
 				A14225BB2577435C00751FAF /* ManagedFeedImage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -17,7 +17,7 @@ public final class LocalFeedImageDataLoader {
     
 }
 
-extension LocalFeedImageDataLoader {
+extension LocalFeedImageDataLoader: FeedImageCache {
     
     public typealias SaveResult = Result<Void, Swift.Error>
     

--- a/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -19,7 +19,7 @@ public final class LocalFeedImageDataLoader {
 
 extension LocalFeedImageDataLoader: FeedImageCache {
     
-    public typealias SaveResult = Result<Void, Swift.Error>
+    public typealias SaveResult = FeedImageCache.Result
     
     public enum SaveError: Error {
         case failed

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -21,9 +21,9 @@ public final class LocalFeedLoader {
 
 }
 
-extension LocalFeedLoader {
+extension LocalFeedLoader: FeedCache {
     
-    public typealias SaveResult = Result<Void, Error>
+    public typealias SaveResult = FeedCache.Result
     
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] deletionResult in

--- a/EssentialFeed/Feed Feature/FeedCache.swift
+++ b/EssentialFeed/Feed Feature/FeedCache.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol FeedCache {
-    typealias SaveResult = Result<Void, Error>
+    typealias Result = Swift.Result<Void, Error>
     
-    func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void)
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/Feed Feature/FeedCache.swift
+++ b/EssentialFeed/Feed Feature/FeedCache.swift
@@ -1,0 +1,15 @@
+//
+//  FeedCache.swift
+//  EssentialFeed
+//
+//  Created by Jair Moreno Gaspar on 10/02/21.
+//  Copyright © 2021 Jair Moreno G. All rights reserved.
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias SaveResult = Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void)
+}

--- a/EssentialFeed/Feed Feature/FeedImageCache.swift
+++ b/EssentialFeed/Feed Feature/FeedImageCache.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol FeedImageCache {
-    typealias SaveResult = Result<Void, Swift.Error>
+    typealias Result = Swift.Result<Void, Swift.Error>
     
-    func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void)
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/Feed Feature/FeedImageCache.swift
+++ b/EssentialFeed/Feed Feature/FeedImageCache.swift
@@ -1,0 +1,15 @@
+//
+//  FeedImageCache.swift
+//  EssentialFeed
+//
+//  Created by Jair Moreno Gaspar on 11/02/21.
+//  Copyright © 2021 Jair Moreno G. All rights reserved.
+//
+
+import Foundation
+
+public protocol FeedImageCache {
+    typealias SaveResult = Result<Void, Swift.Error>
+    
+    func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void)
+}


### PR DESCRIPTION
Create loader cache decorators in load feed and image feed to save the information on succeeded response