### PR TITLE
Fix potential bug

### DIFF
--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -74,6 +74,22 @@ final class FeedUIIntegrationTests: XCTestCase {
         
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut: sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut: sut, isRendering: [])
+        
+    }
+    
     func test_loadCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage()
         let (sut, loader) = makeSUT()

--- a/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -12,6 +12,9 @@ import EssentialFeediOS
 
 extension FeedUIIntegrationTests {
     func assertThat(sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead", file: file, line: line)
         }

--- a/EssentialFeediOS/FeedUI/Controllers/FeedViewController.swift
+++ b/EssentialFeediOS/FeedUI/Controllers/FeedViewController.swift
@@ -18,6 +18,8 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     public var delegate: FeedViewControllerDelegate?
     @IBOutlet private(set) public var errorView: ErrorView?
     
+    private var loadingControllers: [IndexPath: FeedImageCellController] = [:]
+    
     public var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -46,6 +48,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -72,10 +75,13 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
Calling reload data will call didEndDisplaying method which will try to cancel the image loading, however if the feed does not have any feed the app will crash so we keep a reference to the cellControllers to avoid this issue