### PR TITLE
Execute Run loop in the current thread

### DIFF
--- a/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedViewControllerTests+Assertions.swift
@@ -13,7 +13,7 @@ import EssentialFeediOS
 extension FeedUIIntegrationTests {
     func assertThat(sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
         sut.tableView.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+        RunLoop.main.run(until: Date())
         
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead", file: file, line: line)
@@ -22,6 +22,7 @@ extension FeedUIIntegrationTests {
         feed.enumerated().forEach { (index, feed) in
             assertThat(sut: sut, hasViewConfiguredFor: feed, at: index, file: file, line: line)
         }
+        executeRunLoopToCleanUpReferences()
     }
 
     func assertThat(sut: FeedViewController, hasViewConfiguredFor image: FeedImage, at index: Int, file: StaticString = #file, line: UInt = #line) {
@@ -38,5 +39,9 @@ extension FeedUIIntegrationTests {
         XCTAssertEqual(cell.locationText, image.location, "Expected location text to be \(String(describing: image.location)) for image view at index \(index)", file: file, line: line)
         
         XCTAssertEqual(cell.descriptionText, image.description, "Expected description text to be \(String(describing: image.description)) for image view at index \(index)", file: file, line: line)
+    }
+    
+    private func executeRunLoopToCleanUpReferences() {
+        RunLoop.current.run(until: Date())
     }
 }


### PR DESCRIPTION
Execute `RunLoop.current.run(until: Date())`  at the end of assertion function to clean up references and avoid random test failures